### PR TITLE
chore(release): 0.2.0 – login, animations, drag-to-bet, haptics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+All notable changes to this project will be documented here.
+
+## [0.2.0] - 2025-11-02
+### Added
+- **Login screen** with felt backdrop, name/PIN, and “Enter Table” CTA.
+- **Slide-in card animation** (`ui/SlideCard`) for a real-deal feel.
+- **Drag-to-bet** chips (`ui/DragChip`) + chip rack quick-add.
+- **Haptics** (`ui/haptics`) for actions and outcomes.
+- **Onboarding modal** scaffold (`ui/OnboardModal`).
+
+### Changed
+- **RoundScreen** polish pass; improved dealer area and seat layout.
+
+### Fixed
+- Removed invalid `"DOUBLE"` check from outcome buttons; added outcome→haptic map.
+
+### Notes
+- Expo SDK 54 baseline. Run `npx expo install expo-haptics` if missing.
+
+## [0.1.0] - 2025-10-29
+### Added
+- Initial app skeleton, rules engine, coaching, and payouts.

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Learn BJ (Coach)",
     "slug": "learn-while-you-play-blackjack",
-    "version": "1.0.0",
+    "version": "2.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "splash": {


### PR DESCRIPTION
Bump to 0.2.0 with CHANGELOG. Adds Login, SlideCard, DragChip, outcome→haptic map, onboarding.